### PR TITLE
switched time styling

### DIFF
--- a/docs/assets/scripts/script.js
+++ b/docs/assets/scripts/script.js
@@ -89,7 +89,7 @@ $(function () {
     let hourBlock = $("<div>");
 
     hourBlock.addClass("col-2 col-md-1 hour text-center py-3");
-    hourBlock.text(hour);
+    hourBlock.text(date.format("h A"));
 
     timeBlock.append(hourBlock);
     


### PR DESCRIPTION
closes #19
dayJS localized styling is more limitted than expected so unable to match computer, etc. so went with standard US. 